### PR TITLE
Added simple collision detection

### DIFF
--- a/dist/server/math/collisiondetection.d.ts
+++ b/dist/server/math/collisiondetection.d.ts
@@ -1,0 +1,4 @@
+import Vec2 from "./vec2.js";
+export default class CollisionDetector {
+    static axisAlignedBoundBox(pos: Vec2, posWH: Vec2, pos2: Vec2, pos2WH: Vec2): boolean;
+}

--- a/dist/server/math/collisiondetection.js
+++ b/dist/server/math/collisiondetection.js
@@ -1,0 +1,13 @@
+// Paul - (03.16.22)
+export default class CollisionDetector {
+    // simple collision detection algorithm based on coordinates, width, height
+    // assumes collision box doesn't rotate 
+    static axisAlignedBoundBox(pos, posWH, pos2, pos2WH) {
+        if (pos.x < pos2.x + pos2WH.x &&
+            pos.x + posWH.x > pos2.x && pos.y < pos2.y + pos2WH.y &&
+            posWH.y + pos.y > pos2.y) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/dist/server/player/state/movementstate.d.ts
+++ b/dist/server/player/state/movementstate.d.ts
@@ -13,6 +13,15 @@ export default class MovementState extends GremlinState {
     addDirection(dir: Direction): void;
     removeDirection(dir: Direction): void;
     update(dt: number, gremlins: Array<Gremlin>): void;
+    private moveUp;
+    private moveDown;
+    private moveLeft;
+    private moveRight;
+    private moveUpLeft;
+    private moveUpRight;
+    private moveDownLeft;
+    private moveDownRight;
+    private checkCollision;
 }
 export declare enum Direction {
     Idle = 0,

--- a/dist/server/player/state/movementstate.js
+++ b/dist/server/player/state/movementstate.js
@@ -1,5 +1,7 @@
 import GremlinState from './gremlinstate.js';
 import { getGremlinFromID } from '../gremlin.js';
+import CollisionDetector from '../../math/collisiondetection.js';
+import Vec2 from '../../math/vec2.js';
 export default class MovementState extends GremlinState {
     constructor(ownerID) {
         super(ownerID);
@@ -91,34 +93,139 @@ export default class MovementState extends GremlinState {
         else {
             this.direction = Direction.Idle;
         }
+        // Paul - (03.16.22) 
+        // refactored movement into seperate functions
+        // added a rough collision detection against other objects
+        //      collides with other gremlins right now
+        let pos = new Vec2(owner.pos.x, owner.pos.y);
         switch (this.direction) {
             case Direction.Up:
-                owner.pos.offsetY(-this.speed * dt);
+                this.moveUp(pos, dt, gremlins, owner);
                 break;
             case Direction.UpLeft:
-                owner.pos.offsetXY(-this.diagonalSpeed * dt, -this.diagonalSpeed * dt);
+                this.moveUpLeft(pos, dt, gremlins, owner);
                 break;
             case Direction.UpRight:
-                owner.pos.offsetXY(this.diagonalSpeed * dt, -this.diagonalSpeed * dt);
+                this.moveUpRight(pos, dt, gremlins, owner);
                 break;
             case Direction.Down:
-                owner.pos.offsetY(this.speed * dt);
+                this.moveDown(pos, dt, gremlins, owner);
                 break;
             case Direction.DownLeft:
-                owner.pos.offsetXY(-this.diagonalSpeed * dt, this.diagonalSpeed * dt);
+                this.moveDownLeft(pos, dt, gremlins, owner);
                 break;
             case Direction.DownRight:
-                owner.pos.offsetXY(this.diagonalSpeed * dt, this.diagonalSpeed * dt);
+                this.moveDownRight(pos, dt, gremlins, owner);
                 break;
             case Direction.Left:
-                owner.pos.offsetX(-this.speed * dt);
+                this.moveLeft(pos, dt, gremlins, owner);
                 break;
             case Direction.Right:
-                owner.pos.offsetX(this.speed * dt);
+                this.moveRight(pos, dt, gremlins, owner);
                 break;
             case Direction.Idle:
                 break;
         }
+    }
+    // Paul - (03.16.22) 
+    // check for collisions and move the gremlin if no collision exist
+    moveUp(pos, dt, gremlins, owner) {
+        pos.offsetY(-this.speed * dt);
+        if (this.checkCollision(this.ownerID, pos, gremlins) == false) {
+            owner.pos.offsetY(-this.speed * dt);
+            return true;
+        }
+        return false;
+    }
+    moveDown(pos, dt, gremlins, owner) {
+        pos.offsetY(this.speed * dt);
+        if (this.checkCollision(this.ownerID, pos, gremlins) == false) {
+            owner.pos.offsetY(this.speed * dt);
+            return true;
+        }
+        return false;
+    }
+    moveLeft(pos, dt, gremlins, owner) {
+        pos.offsetX(-this.speed * dt);
+        if (this.checkCollision(this.ownerID, pos, gremlins) == false) {
+            owner.pos.offsetX(-this.speed * dt);
+            return true;
+        }
+        return false;
+    }
+    moveRight(pos, dt, gremlins, owner) {
+        pos.offsetX(this.speed * dt);
+        if (this.checkCollision(this.ownerID, pos, gremlins) == false) {
+            owner.pos.offsetX(this.speed * dt);
+            return true;
+        }
+        return false;
+    }
+    moveUpLeft(pos, dt, gremlins, owner) {
+        pos.offsetXY(-this.diagonalSpeed * dt, -this.diagonalSpeed * dt);
+        if (this.checkCollision(this.ownerID, pos, gremlins) == true) { // if we collide going diagonal, check if we can still move in x or y
+            pos.x = owner.pos.x;
+            if (this.moveUp(pos, dt, gremlins, owner) == false) {
+                pos.y = owner.pos.y;
+                this.moveLeft(pos, dt, gremlins, owner);
+            }
+        }
+        else {
+            owner.pos.offsetXY(-this.diagonalSpeed * dt, -this.diagonalSpeed * dt);
+        }
+    }
+    moveUpRight(pos, dt, gremlins, owner) {
+        pos.offsetXY(this.diagonalSpeed * dt, -this.diagonalSpeed * dt);
+        if (this.checkCollision(this.ownerID, pos, gremlins) == true) { // if we collide going diagonal, check if we can still move in x or y
+            pos.x = owner.pos.x; // reset position 
+            if (this.moveUp(pos, dt, gremlins, owner) == false) {
+                pos.y = owner.pos.y; // reset position
+                this.moveRight(pos, dt, gremlins, owner);
+            }
+        }
+        else { // doesn't collide
+            owner.pos.offsetXY(this.diagonalSpeed * dt, -this.diagonalSpeed * dt);
+        }
+    }
+    moveDownLeft(pos, dt, gremlins, owner) {
+        pos.offsetXY(-this.diagonalSpeed * dt, this.diagonalSpeed * dt);
+        if (this.checkCollision(this.ownerID, pos, gremlins) == true) { // if we collide going diagonal, check if we can still move in x or y
+            pos.x = owner.pos.x;
+            if (this.moveDown(pos, dt, gremlins, owner) == false) {
+                pos.y = owner.pos.y;
+                this.moveLeft(pos, dt, gremlins, owner);
+            }
+        }
+        else { // doesn't collide
+            owner.pos.offsetXY(-this.diagonalSpeed * dt, this.diagonalSpeed * dt);
+        }
+    }
+    // Paul - (03.16.22) 
+    moveDownRight(pos, dt, gremlins, owner) {
+        pos.offsetXY(this.diagonalSpeed * dt, this.diagonalSpeed * dt);
+        if (this.checkCollision(this.ownerID, pos, gremlins) == true) { // if we collide going diagonal, check if we can still move in x or y
+            pos.x = owner.pos.x;
+            if (this.moveDown(pos, dt, gremlins, owner) == false) {
+                pos.y = owner.pos.y;
+                this.moveRight(pos, dt, gremlins, owner);
+            }
+        }
+        else { // doesn't collide
+            owner.pos.offsetXY(this.diagonalSpeed * dt, this.diagonalSpeed * dt);
+        }
+    }
+    // Paul - (03.16.22)
+    // run a collision check on each gremlin 
+    // the number of checks needs to be reduced...hash table maybe? 
+    checkCollision(gremlinId, pos, gremlins) {
+        var collision = false;
+        gremlins.forEach(g => {
+            // 72 is the height and width of the gremlin currently. Need a better way to get the width/height of collision objects
+            if (g.gremlinID != gremlinId && CollisionDetector.axisAlignedBoundBox(g.pos, new Vec2(72 - 15, 72 - 22), pos, new Vec2(72 - 15, 72 - 22))) {
+                collision = true;
+            }
+        });
+        return collision;
     }
 }
 export var Direction;

--- a/dist/server/world/gremlinworld.js
+++ b/dist/server/world/gremlinworld.js
@@ -14,6 +14,13 @@ export default class GremlinWorld {
         this.gameGremlins.forEach(gremlin => {
             gremlin.update(dt, this.gameGremlins);
         });
+        // this.gameGremlins.forEach(gremlin => {
+        //     this.gameGremlins.forEach(g => {
+        //         if (g.gremlinID != gremlin.gremlinID && CollisionDetector.axisAlignedBoundBox(g.pos, new Vec2(72, 72), gremlin.pos, new Vec2(72, 72))) {
+        //         } else {
+        //         }
+        //     });
+        // });
     }
     dispatchCommandToID(id, gcStateChangeCommand) {
         const gremlin = getGremlinFromID(id, this.gameGremlins);

--- a/src/client/application/gremlinclient.ts
+++ b/src/client/application/gremlinclient.ts
@@ -44,7 +44,7 @@ export default class GremlinClient {
             this.gsWelcome();
             this.gsFallenGremlin();
             this.gsGremlinPackage();
-            
+
         });
 
         document.onkeyup = this.handleKeyUp.bind(this);
@@ -86,21 +86,39 @@ export default class GremlinClient {
 
         this.socket.on('gsGremlinPackage', (serverPackage: any) => {
             if (this.isPlaying) {
+                var clientGremlin = null;
                 //(3/13/22) reset the fellowGremlins array and repopulate it from the GremlinPackage
                 for (let i = 0; i < serverPackage[0].connectedGremlins.length; i++) {
                     const currentGremlin = serverPackage[0].connectedGremlins[i];
+                    // Paul - (03.16.22)
+                    // catch player gremlin from being added yet
+                    if (currentGremlin.gremlinID == this.gremlinID) {
+                        clientGremlin = currentGremlin;
+                    } else {
+                        // Paul - (03.15.22)
+                        // reassign existing gremlins and add new gremlins to map
+                        const existingGremlin = this.fellowGremlins.get(currentGremlin.gremlinID);
+                        if (existingGremlin) {
+                            existingGremlin.targetPos = currentGremlin.pos
+                        }
+                        else {
+                            this.fellowGremlins.set(currentGremlin.gremlinID, new gcGremlin(currentGremlin.gremlinID, currentGremlin.name, currentGremlin.pos));
+                        }
+                    }
+                }
 
-                    // Paul - (03.15.22)
-                    // instead of resetting list I rely on a map to update already existing gremlins
-                    // currently doesn't remove gremlins if they're not part of the serverPackage 
-                    // maybe a seperate socket event for disconnects to avoid copying the map over ?
-                    //      or make a temp map that reassign this.fellowGremlins with new gcGremlin objects after seeing what exists 
-                    const existingGremlin = this.fellowGremlins.get(currentGremlin.gremlinID);
+                // Paul - (03.16.22)
+                // add gremlin to the bottom of the map (when casting to array the map values will be reversed)
+                if (clientGremlin) {
+                    const existingGremlin = this.fellowGremlins.get(clientGremlin.gremlinID);
                     if (existingGremlin) {
-                        existingGremlin.targetPos = currentGremlin.pos
+                        this.fellowGremlins.delete(clientGremlin.gremlinID);
+                        const newGremlin = new gcGremlin(clientGremlin.gremlinID, clientGremlin.name, existingGremlin.pos);
+                        newGremlin.targetPos = clientGremlin.pos;
+                        this.fellowGremlins.set(clientGremlin.gremlinID, newGremlin);
                     }
                     else {
-                        this.fellowGremlins.set(currentGremlin.gremlinID, new gcGremlin(currentGremlin.gremlinID, currentGremlin.name, currentGremlin.pos));
+                        this.fellowGremlins.set(clientGremlin.gremlinID, new gcGremlin(clientGremlin.gremlinID, clientGremlin.name, clientGremlin.pos));
                     }
                 }
 
@@ -113,7 +131,6 @@ export default class GremlinClient {
     }
 
     //end of callbacks
-
     private shoutID() {
         console.log(`shouting shoutING ${this.gremlinID}`);
     }

--- a/src/server/math/collisiondetection.ts
+++ b/src/server/math/collisiondetection.ts
@@ -1,0 +1,15 @@
+import Vec2 from "./vec2.js";
+
+// Paul - (03.16.22)
+export default class CollisionDetector {
+    // simple collision detection algorithm based on coordinates, width, height
+    // assumes collision box doesn't rotate 
+    static axisAlignedBoundBox(pos: Vec2, posWH: Vec2, pos2: Vec2, pos2WH: Vec2,): boolean {
+        if (pos.x < pos2.x + pos2WH.x &&
+            pos.x + posWH.x > pos2.x && pos.y < pos2.y + pos2WH.y &&
+            posWH.y + pos.y > pos2.y) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/server/world/gremlinworld.ts
+++ b/src/server/world/gremlinworld.ts
@@ -3,6 +3,8 @@ import GremlinPackage from './gremlinpackage.js';
 
 // Paul - (03.15.22) - was getting import errors from performance
 import { performance } from 'perf_hooks';
+import CollisionDetector from '../math/collisiondetection.js';
+import Vec2 from '../math/vec2.js';
 
 export default class GremlinWorld {
     private dt: number;
@@ -24,6 +26,17 @@ export default class GremlinWorld {
         this.gameGremlins.forEach(gremlin => {
             gremlin.update(dt, this.gameGremlins);
         });
+        // this.gameGremlins.forEach(gremlin => {
+        //     this.gameGremlins.forEach(g => {
+        //         if (g.gremlinID != gremlin.gremlinID && CollisionDetector.axisAlignedBoundBox(g.pos, new Vec2(72, 72), gremlin.pos, new Vec2(72, 72))) {
+
+        //         } else {
+
+        //         }
+        //     });
+
+        // });
+
     }
 
     public dispatchCommandToID(id: string, gcStateChangeCommand: any) {


### PR DESCRIPTION
Added simple axis-aligned bounding box algorithm. The server checks each gremlin against each other in movementstate.ts and prevents movement if a collision is detected. The number of collision checks this has to run is terrible, but there are solutions like a hash table or checking for all collisions at once, instead of on each individual gremlin. 

The client now catches the user's gremlin and adds it at the bottom of the map so the render function draws the user's gremlin on top of others.