### PR TITLE
on load player "jumps" to first pos, testing fix

### DIFF
--- a/dist/public/client/application/gremlinclient.js
+++ b/dist/public/client/application/gremlinclient.js
@@ -177,7 +177,7 @@ export default class GremlinClient {
         this.gCanvas.update(dt);
     }
     render() {
-        if (this.selfGremlin) {
+        if (this.selfGremlin && this.selfStartingPos.x != 0 && this.selfStartingPos.y != 0) {
             this.gCanvas.render(this.selfGremlin);
         }
     }

--- a/src/client/application/gremlinclient.ts
+++ b/src/client/application/gremlinclient.ts
@@ -226,7 +226,7 @@ export default class GremlinClient {
     }
 
     private render(): void {
-        if (this.selfGremlin) {
+        if (this.selfGremlin && this.selfStartingPos.x != 0 && this.selfStartingPos.y != 0) {
             this.gCanvas.render(this.selfGremlin);
         }
     }


### PR DESCRIPTION
rare instance of different behavior on localhost vs live deploy
localhost the player more or less instantly appears at their starting position, on live deployment the player rapidly moves there from the top left corner of the screen